### PR TITLE
Adding library to support close method

### DIFF
--- a/src/ethtool-stats.c
+++ b/src/ethtool-stats.c
@@ -27,6 +27,7 @@
 #include <ifaddrs.h>
 #include <linux/sockios.h>
 #include <linux/ethtool.h>
+#include <unistd.h>
 
 #include "ethtool-snmpd.h"
 


### PR DESCRIPTION
Encountered a compilation error using the master branch on rocky linux 10.  Adding the unistd.h library allows calling close directly:

```
+ /usr/bin/make -O -j2 V=1 VERBOSE=1 V=1 'CFLAGS=-fPIE -g -O2' 'LDFLAGS=-fPIE -pie'
Making all in src
make[1]: Entering directory '/root/rpmbuild/BUILD/ethtool-snmpd-master/src'
gcc -DPACKAGE_NAME=\"ethtool-snmpd\" -DPACKAGE_TARNAME=\"ethtool-snmpd\" -DPACKAGE_VERSION=\"2025-06-15\" -DPACKAGE_STRING=\"ethtool-snmpd\ 2025-06-15\" -DPACKAGE_BUGREPORT=\"bernat@luffy.cx\" -DPACKAGE_URL=\"\" -DPACKAGE=\"ethtool-snmpd\" -DVERSION=\"2025-06-15\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_ETHTOOL_H=1 -DHAVE_NETSNMP_ENABLE_SUBAGENT=1 -I.  -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE  -fdiagnostics-show-option -pipe -Wall -W -Wextra -Wformat -Wformat-security -Wfatal-errors -Wcast-align -Winline -fstack-protector -Wno-unused-parameter -Wno-missing-field-initializers -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fPIE -DNETSNMP_ENABLE_IPV6 -fno-strict-aliasing -DNETSNMP_REMOVE_U64 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fPIE -Ulinux -Dlinux=linux -D_REENTRA
[build.log](https://github.com/user-attachments/files/20750772/build.log)
NT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/lib64/perl5/CORE -I/usr/include -DNETSNMP_NO_INLINE -fPIE -g -O2 -MT ethtool_snmpd-ethtool-stats.o -MD -MP -MF .deps/ethtool_snmpd-ethtool-stats.Tpo -c -o ethtool_snmpd-ethtool-stats.o `test -f 'ethtool-stats.c' || echo './'`ethtool-stats.c
ethtool-stats.c: In function ‘refresh_cache’:
ethtool-stats.c:169:18: error: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
  169 |   if (skfd >= 0) close(skfd);
      |                  ^~~~~
      |                  pclose
compilation terminated due to -Wfatal-errors.
make[1]: *** [Makefile:456: ethtool_snmpd-ethtool-stats.o] Error 1
make[1]: Leaving directory '/root/rpmbuild/BUILD/ethtool-snmpd-master/src'
make[1]: *** Waiting for unfinished jobs....
make[1]: Entering directory '/root/rpmbuild/BUILD/ethtool-snmpd-master/src'
gcc -DPACKAGE_NAME=\"ethtool-snmpd\" -DPACKAGE_TARNAME=\"ethtool-snmpd\" -DPACKAGE_VERSION=\"2025-06-15\" -DPACKAGE_STRING=\"ethtool-snmpd\ 2025-06-15\" -DPACKAGE_BUGREPORT=\"bernat@luffy.cx\" -DPACKAGE_URL=\"\" -DPACKAGE=\"ethtool-snmpd\" -DVERSION=\"2025-06-15\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_ETHTOOL_H=1 -DHAVE_NETSNMP_ENABLE_SUBAGENT=1 -I.  -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE  -fdiagnostics-show-option -pipe -Wall -W -Wextra -Wformat -Wformat-security -Wfatal-errors -Wcast-align -Winline -fstack-protector -Wno-unused-parameter -Wno-missing-field-initializers -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fPIE -DNETSNMP_ENABLE_IPV6 -fno-strict-aliasing -DNETSNMP_REMOVE_U64 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fPIE -Ulinux -Dlinux=linux -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/lib64/perl5/CORE -I/usr/include -DNETSNMP_NO_INLINE -fPIE -g -O2 -MT ethtool_snmpd-main.o -MD -MP -MF .deps/ethtool_snmpd-main.Tpo -c -o ethtool_snmpd-main.o `test -f 'main.c' || echo './'`main.c
mv -f .deps/ethtool_snmpd-main.Tpo .deps/ethtool_snmpd-main.Po
make[1]: Leaving directory '/root/rpmbuild/BUILD/ethtool-snmpd-master/src'
make: *** [Makefile:462: all-recursive] Error 1
error: Bad exit status from /var/tmp/rpm-tmp.D3Rs22 (%build)
```

Full build log attached.

[build.log](https://github.com/user-attachments/files/20750775/build.log)